### PR TITLE
Analysis field is optional when there is -c flag for mystem

### DIFF
--- a/src/main/scala/ru/stachek66/nlp/mystem/parsing/JsonRepresentationParser.scala
+++ b/src/main/scala/ru/stachek66/nlp/mystem/parsing/JsonRepresentationParser.scala
@@ -4,7 +4,7 @@ import org.json.JSONArray
 import ru.stachek66.nlp.mystem.model.Info
 
 /**
- * alexeyev 
+ * alexeyev
  * 31.08.14.
  */
 object JsonRepresentationParser {
@@ -16,24 +16,30 @@ object JsonRepresentationParser {
     //todo: fix and enable GrammarInfo parsing
 
     val stuff: Traversable[Info] =
-      for (i <- 0 to json.length - 1)
-      yield {
-        val item = json.getJSONObject(i)
-        val initial = item.getString("text")
-        val analysis = item.getJSONArray("analysis")
+      for (i <- 0 until json.length)
+        yield {
+          val item = json.getJSONObject(i)
+          val initial = item.getString("text")
 
-        if (analysis.length() == 0)
-          Info(initial, None, item.toString)
-        else {
-          val result =
-            for (j <- 0 to analysis.length - 1)
-            yield {
-              val anItem = analysis.getJSONObject(j)
-              new Info(initial, Option(anItem.getString("lex")), item.toString)
+          if (item.has("analysis")) {
+            val analysis = item.getJSONArray("analysis")
+
+            if (analysis.length() == 0)
+              Info(initial, None, item.toString)
+            else {
+              val result =
+                for (j <- 0 until analysis.length)
+                  yield {
+                    val anItem = analysis.getJSONObject(j)
+                    new Info(initial, Option(anItem.getString("lex")), item.toString)
+                  }
+              result.head
             }
-          result.head
+          } else {
+            Info(initial, None, item.toString)
+          }
+
         }
-      }
     stuff
   }
 }


### PR DESCRIPTION
When I'm creating mystem with -c flag ( `--format json -e utf-8 -c` ) and parsing a string "окна 1128", I'm getting Json parse exception (missing analysis field).

When starting mystem 3.0 with `--format json -e utf-8 -c`  and typing "окна 1128" it responds with:

```
[{"analysis":[{"lex":"окно"}],"text":"окна"},{"text":" "},{"text":"1128"},{"text":"\n"}]
```

This patch returns initial in case there is no "analysis" field.
