### PR TITLE
new version, mainly issue #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ The artifact is cross-built for **Scala 2.12** and **Scala 2.13**.
 
 ### Maven
 
+TODO: deploy recent improvements
+
+
 ```xml
 <!-- For Scala 2.13 -->
 <dependency>

--- a/README.md
+++ b/README.md
@@ -145,6 +145,50 @@ since `MyStem` implements `java.lang.AutoCloseable`.
 
 ## Changelog
 
+### 0.3.1
+
+- **`GrammarInfo.person` (API change).** The `1p` / `2p` / `3p` person
+  tags emitted by mystem are now populated into a new `person:
+  Set[Person.Value]` field. Previously the parser silently dropped them
+  on the floor. Note: positional constructor calls to `GrammarInfo` will
+  break — named-argument call sites are unaffected.
+- **Parens-pipe `gr` parsing.** Real mystem 3.x output with `--weight`
+  emits multi-analysis strings like
+  `A,plen=(acc,sg,m,anim|gen,sg,m|gen,sg,n)`. The pre-existing parser
+  threw `NoSuchElementException` on the leading `(`. New
+  `GrammarInfoParsing.toGrammarInfos(s): List[GrammarInfo]` returns one
+  `GrammarInfo` per pipe-alternative; the previous `toGrammarInfo`
+  remains and now returns the most-likely interpretation (mystem orders
+  alternatives by descending probability, so `.head`).
+- **Wire-format aliases.** mystem 3.x emits `indic` (we declared
+  `Value("ind")` for indicative mood) and `praet` (we declared
+  `Value("past")` for past tense). Without alias support every real
+  verb output threw on parsing. `GrammarMapBuilder.aliases` (public)
+  now maps `indic`→`ind` and `praet`→`past`; both forms parse.
+- **Process robustness.** `ExternalProcessServer.syncRequest` no
+  longer spins forever in `while (!reader.ready()) {}` when the child
+  process exits without responding — `BufferedReader.ready()` returns
+  `false` at EOF, not true. The busy-wait now also gates on
+  `process.isAlive`, the drain loop breaks on `null` (avoiding
+  appending the literal string `"null"`), and an exit-without-output
+  surfaces as `IOException("process exited before producing any
+  response")` so `FailSafeExternalProcessServer` can spawn a fresh
+  child rather than wrap an empty success. The restart-on-death path
+  is now functionally testable.
+- **Refactor:** `Factory.getExecutable`'s cached-binary version check
+  is extracted into `private[holding] isCorrectVersion(file, version):
+  Boolean`. Same observable contract, but the version-matching logic
+  is now exercisable in unit tests without hitting the CDN.
+- **Test coverage.** ~70 new tests (75 → 140 across 15 test classes).
+  Statement coverage > 80%, branch coverage > 74% under scoverage.
+  Direct unit tests for `syncRequest` (using `python3 -u` as a portable
+  line-buffered echo stand-in), `isCorrectVersion`, `MyStem.normalize`,
+  `MyStemApplicationException`, archive edge cases (empty archive,
+  directory-as-first-entry), `FailSafeExternalProcessServer`
+  restart-on-death, plus broader coverage of `GrammarInfoParsing`
+  (parens-pipe alternatives, person, alias support, fail-loud on
+  unknown tags inside parens).
+
 ### 0.3.0
 
 - **Fixed process leak (#3):** `MyStem` now extends `AutoCloseable`; an

--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ TODO: deploy recent improvements
 <dependency>
     <groupId>ru.stachek66.nlp</groupId>
     <artifactId>mystem-scala_2.13</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.1</version>
 </dependency>
 
 <!-- For Scala 2.12 -->
 <dependency>
     <groupId>ru.stachek66.nlp</groupId>
     <artifactId>mystem-scala_2.12</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.1</version>
 </dependency>
 ```
 

--- a/src/main/scala/ru/stachek66/nlp/mystem/holding/Factory.scala
+++ b/src/main/scala/ru/stachek66/nlp/mystem/holding/Factory.scala
@@ -55,19 +55,12 @@ class Factory(parsingOptions: String = "-igd --eng-gr --format json --weight") {
 
     if (destFile.exists) {
       log.info("Old executable file found")
-
-      try {
-        val suggestedVersion = (destFile.getAbsolutePath + " -v").!!
-        log.info("Version | " + suggestedVersion)
-        if (suggestedVersion.contains(version))
-          destFile
-        else
-          throw new Exception("Wrong version!")
-      } catch {
-        case e: Exception =>
-          log.warn("Removing old binary files...", e)
-          val _ = destFile.delete()
-          getExecutable(version)
+      if (isCorrectVersion(destFile, version)) {
+        destFile
+      } else {
+        log.warn(s"Wrong version at ${destFile.getAbsolutePath}; removing old binary file")
+        val _ = destFile.delete()
+        getExecutable(version)
       }
     } else {
       Tools.withAttempt(10, 1.second) {
@@ -89,5 +82,32 @@ class Factory(parsingOptions: String = "-igd --eng-gr --format json --weight") {
       }
     }
   }
+
+  /** Run `<executable> -v` and check whether the printed version line
+    * contains the requested version string. Used by [[getExecutable]] to
+    * decide whether to reuse a cached binary or delete it and re-fetch.
+    *
+    * Returns `false` rather than throwing on any failure (file missing,
+    * non-executable, exits non-zero, prints something we can't read) —
+    * the caller's response to "version doesn't match" is the same as
+    * "couldn't tell": delete and re-fetch.
+    *
+    * `private[holding]` to expose for unit testing without making it
+    * part of the public Factory API.
+    */
+  private[holding] def isCorrectVersion(executable: java.io.File, version: String): Boolean =
+    scala.util.Try {
+      // `!!` runs the process and returns stdout, throwing if the command
+      // can't be exec'd or exits non-zero. Both failure modes correctly
+      // collapse into "Failure" here and become `false` below.
+      val printed = (executable.getAbsolutePath + " -v").!!
+      log.info(s"Version probe on ${executable.getName} printed: ${printed.trim}")
+      printed.contains(version)
+    } match {
+      case scala.util.Success(matches) => matches
+      case scala.util.Failure(t) =>
+        log.warn(s"Could not check version of ${executable.getAbsolutePath}: ${t.getMessage}")
+        false
+    }
 
 }

--- a/src/main/scala/ru/stachek66/nlp/mystem/model/GrammarInfo.scala
+++ b/src/main/scala/ru/stachek66/nlp/mystem/model/GrammarInfo.scala
@@ -8,6 +8,7 @@ case class GrammarInfo(
   tense: Set[Tense.Value] = Set.empty,
   `case`: Set[Case.Value] = Set.empty,
   number: Set[Number.Value] = Set.empty,
+  person: Set[Person.Value] = Set.empty[Person.Value],
   verbFormInfo: Set[VerbForms.Value] = Set.empty[VerbForms.Value],
   adjFormInfo: Set[AdjectiveForms.Value] = Set.empty[AdjectiveForms.Value],
   gender: Set[Gender.Value] = Set.empty,

--- a/src/main/scala/ru/stachek66/nlp/mystem/model/GrammarInfoParts.scala
+++ b/src/main/scala/ru/stachek66/nlp/mystem/model/GrammarInfoParts.scala
@@ -5,13 +5,40 @@ package ru.stachek66.nlp.mystem.model
   */
 object GrammarMapBuilder {
 
-  // todo: make sure everything is covered
+  /** Aliases between the wire-format tag names mystem 3.x actually emits
+    * and the canonical names hard-coded into the [[Enumeration]] objects
+    * below. mystem's docs and its real output diverge — `mystem -igd`
+    * emits `indic` for indicative mood (we declared `ind`) and `praet`
+    * for past tense (we declared `past`). The pre-3.x naming was kept
+    * for backward compatibility of `Value.toString` output, but real
+    * output has to parse, so we map alias → canonical here.
+    *
+    * Public so callers who manually post-process tag strings can use the
+    * same canonicalisation rules as the parser.
+    */
+  val aliases: Map[String, String] = Map(
+    "indic" -> "ind",   // VerbForms.indicativeMood
+    "praet" -> "past"   // Tense.past
+  )
 
-  lazy val tagToEnumMap: Map[String, Enumeration] =
-    (tagToEnum(POS) ++ tagToEnum(Tense) ++ tagToEnum(Animacy) ++
-      tagToEnum(Aspect) ++ tagToEnum(VerbForms) ++ tagToEnum(Gender) ++
-      tagToEnum(Number) ++ tagToEnum(Voice) ++ tagToEnum(Other) ++
-      tagToEnum(AdjectiveForms) ++ tagToEnum(Person) ++ tagToEnum(Case)).toMap
+  /** The canonical (Enumeration-Value-side) form of a wire-format tag. */
+  def canonical(tag: String): String = aliases.getOrElse(tag, tag)
+
+  /** Tag-string → enclosing Enumeration. Includes both the canonical
+    * names (every Value emitted by every Enumeration below) AND every
+    * alias entry from [[aliases]] mapped to the canonical name's enum.
+    */
+  lazy val tagToEnumMap: Map[String, Enumeration] = {
+    val canonicalMap: Map[String, Enumeration] =
+      (tagToEnum(POS) ++ tagToEnum(Tense) ++ tagToEnum(Animacy) ++
+        tagToEnum(Aspect) ++ tagToEnum(VerbForms) ++ tagToEnum(Gender) ++
+        tagToEnum(Number) ++ tagToEnum(Voice) ++ tagToEnum(Other) ++
+        tagToEnum(AdjectiveForms) ++ tagToEnum(Person) ++ tagToEnum(Case)).toMap
+
+    canonicalMap ++ aliases.flatMap {
+      case (alias, canon) => canonicalMap.get(canon).map(alias -> _)
+    }
+  }
 
   private def tagToEnum(enum: Enumeration): Set[(String, Enumeration)] =
     // `values.iterator.toSet` is cross-version-safe; `values.unsorted` was

--- a/src/main/scala/ru/stachek66/nlp/mystem/model/GrammarInfoParts.scala
+++ b/src/main/scala/ru/stachek66/nlp/mystem/model/GrammarInfoParts.scala
@@ -17,8 +17,8 @@ object GrammarMapBuilder {
     * same canonicalisation rules as the parser.
     */
   val aliases: Map[String, String] = Map(
-    "indic" -> "ind",   // VerbForms.indicativeMood
-    "praet" -> "past"   // Tense.past
+    "indic" -> "ind", // VerbForms.indicativeMood
+    "praet" -> "past" // Tense.past
   )
 
   /** The canonical (Enumeration-Value-side) form of a wire-format tag. */
@@ -35,9 +35,7 @@ object GrammarMapBuilder {
         tagToEnum(Number) ++ tagToEnum(Voice) ++ tagToEnum(Other) ++
         tagToEnum(AdjectiveForms) ++ tagToEnum(Person) ++ tagToEnum(Case)).toMap
 
-    canonicalMap ++ aliases.flatMap {
-      case (alias, canon) => canonicalMap.get(canon).map(alias -> _)
-    }
+    canonicalMap ++ aliases.flatMap { case (alias, canon) => canonicalMap.get(canon).map(alias -> _) }
   }
 
   private def tagToEnum(enum: Enumeration): Set[(String, Enumeration)] =

--- a/src/main/scala/ru/stachek66/nlp/mystem/parsing/GrammarInfoParsing.scala
+++ b/src/main/scala/ru/stachek66/nlp/mystem/parsing/GrammarInfoParsing.scala
@@ -2,23 +2,80 @@ package ru.stachek66.nlp.mystem.parsing
 
 import ru.stachek66.nlp.mystem.model._
 
+/** Parser for mystem's comma-separated grammatical-tag strings.
+  *
+  * mystem emits two related shapes in its `gr` field:
+  *
+  *   - Single-analysis form: `S,m,inan=nom,sg`. One unambiguous parse.
+  *
+  *   - Multi-analysis form with mutually-exclusive alternatives:
+  *     `A,plen=(acc,sg,m,anim|gen,sg,m|gen,sg,n)`. Tags before `=(...)`
+  *     apply to every alternative; the alternatives are separated by `|`
+  *     inside the parens. This is the format mystem 3.x emits whenever the
+  *     wrapper passes `--weight` (which the default `Factory` does), so any
+  *     production caller will see it.
+  *
+  * Use `toGrammarInfos` to get every alternative as its own [[GrammarInfo]];
+  * use `toGrammarInfo` for the single-most-likely parse (mystem orders
+  * alternatives by descending probability, so `.head` is "most likely").
+  */
 object GrammarInfoParsing {
 
-  /** Parse mystem's comma-separated tag string into a typed [[GrammarInfo]].
+  /** Captures `<fixed>=(<alternatives>)` where:
+    *   - group 1 includes the trailing `=` so we can prefix it onto each
+    *     alternative without further surgery;
+    *   - group 2 is the `|`-separated alternatives, possibly empty.
     *
-    * The previous implementation used `mapValues`, which in Scala 2.13 returns
-    * a lazy `MapView` and emits a deprecation warning under `-Xlint`. We now
-    * use `Map#map` directly, which is well-defined and identical in semantics
-    * on both Scala 2.12 and 2.13.
+    * Anchored to start/end to avoid matching parens that aren't the
+    * top-level alternatives wrapper. We use `[^)]*` rather than `.*` so a
+    * stray `(` deeper in the string doesn't get pulled in by greedy match.
     */
-  def toGrammarInfo(commaSeparatedTags: String): GrammarInfo = {
+  private val parensPattern = """^(.*=)\(([^)]*)\)$""".r
+
+  /** Parse mystem's tag string into one [[GrammarInfo]] per parens-alternative.
+    *
+    * For non-parens input the result is a single-element list — callers can
+    * always work with `List[GrammarInfo]` and not special-case the simple
+    * shape.
+    */
+  def toGrammarInfos(commaSeparatedTags: String): List[GrammarInfo] =
+    commaSeparatedTags match {
+      case parensPattern(prefix, inner) =>
+        // `inner.split('|')` returns Array("") for an empty inner string,
+        // which gives us a single GrammarInfo built from just the prefix —
+        // that's the right behavior for the degenerate `S=()` shape.
+        inner.split('|').iterator.map(alt => parseSingleAnalysis(prefix + alt)).toList
+      case _ =>
+        List(parseSingleAnalysis(commaSeparatedTags))
+    }
+
+  /** Parse the most-likely interpretation as a single [[GrammarInfo]].
+    *
+    * For non-parens input, identical to the old behavior. For parens input,
+    * returns the first alternative — mystem orders alternatives by
+    * descending probability, so this is the "best guess" interpretation.
+    *
+    * Use [[toGrammarInfos]] when you need every alternative.
+    */
+  def toGrammarInfo(commaSeparatedTags: String): GrammarInfo =
+    toGrammarInfos(commaSeparatedTags).head
+
+  /** Parse a flat (non-parens) tag string. The previous implementation
+    * used `mapValues`, which in Scala 2.13 returns a lazy `MapView` and
+    * emits a deprecation warning under `-Xlint`. We use `Map#map` directly,
+    * which is well-defined and identical in semantics on both 2.12 and 2.13.
+    */
+  private def parseSingleAnalysis(commaSeparatedTags: String): GrammarInfo = {
 
     val mappedEnums: Map[Enumeration, Vector[Enumeration#Value]] = commaSeparatedTags
       .split("[,=]")
       .iterator
       .map { name =>
+        // Look up the enum by the wire-format name (alias or canonical),
+        // but compute the actual Value via withName(canonical(name)) —
+        // Scala's Enumeration#withName has no notion of aliases.
         val obj: Enumeration = GrammarMapBuilder.tagToEnumMap(name)
-        (obj, obj.withName(name))
+        (obj, obj.withName(GrammarMapBuilder.canonical(name)))
       }
       .toVector
       .groupBy { case (obj, _) => obj }
@@ -34,6 +91,7 @@ object GrammarInfoParsing {
       tense = findByEnum(Tense),
       `case` = findByEnum(Case),
       number = findByEnum(Number),
+      person = findByEnum(Person),
       verbFormInfo = findByEnum(VerbForms),
       adjFormInfo = findByEnum(AdjectiveForms),
       gender = findByEnum(Gender),
@@ -44,8 +102,18 @@ object GrammarInfoParsing {
     )
   }
 
+  /** Re-emit a [[GrammarInfo]] as a flat comma-separated tag string.
+    *
+    * This is intentionally lossy: it does NOT reproduce the
+    * `prefix=variable` or parens-alternative structure of the original
+    * input — those are wire-format concerns of mystem, not of the parsed
+    * model. It does include every set value across every dimension, in a
+    * form that round-trips through [[toGrammarInfo]] for any single
+    * (non-alternative) analysis.
+    */
   def toStringRepresentation(gi: GrammarInfo): String =
     (gi.`case` ++ gi.adjFormInfo ++ gi.animacy ++ gi.aspect ++ gi.gender ++
-      gi.number ++ gi.pos ++ gi.other ++ gi.tense ++ gi.verbFormInfo ++ gi.voice).mkString(",")
+      gi.number ++ gi.person ++ gi.pos ++ gi.other ++ gi.tense ++
+      gi.verbFormInfo ++ gi.voice).mkString(",")
 
 }

--- a/src/main/scala/ru/stachek66/nlp/mystem/parsing/GrammarInfoParsing.scala
+++ b/src/main/scala/ru/stachek66/nlp/mystem/parsing/GrammarInfoParsing.scala
@@ -45,8 +45,7 @@ object GrammarInfoParsing {
         // which gives us a single GrammarInfo built from just the prefix —
         // that's the right behavior for the degenerate `S=()` shape.
         inner.split('|').iterator.map(alt => parseSingleAnalysis(prefix + alt)).toList
-      case _ =>
-        List(parseSingleAnalysis(commaSeparatedTags))
+      case _ => List(parseSingleAnalysis(commaSeparatedTags))
     }
 
   /** Parse the most-likely interpretation as a single [[GrammarInfo]].
@@ -57,8 +56,7 @@ object GrammarInfoParsing {
     *
     * Use [[toGrammarInfos]] when you need every alternative.
     */
-  def toGrammarInfo(commaSeparatedTags: String): GrammarInfo =
-    toGrammarInfos(commaSeparatedTags).head
+  def toGrammarInfo(commaSeparatedTags: String): GrammarInfo = toGrammarInfos(commaSeparatedTags).head
 
   /** Parse a flat (non-parens) tag string. The previous implementation
     * used `mapValues`, which in Scala 2.13 returns a lazy `MapView` and

--- a/src/main/scala/ru/stachek66/tools/external/ExternalProcessServer.scala
+++ b/src/main/scala/ru/stachek66/tools/external/ExternalProcessServer.scala
@@ -48,13 +48,39 @@ private[external] class ExternalProcessServer(starterCommand: String) extends Sy
     writer.newLine()
     writer.flush()
 
-    // Block until the first byte of the response is available...
-    while (!reader.ready()) {}
+    // Block until the first byte of the response is available — or the
+    // process exits without producing one. BufferedReader.ready() actually
+    // returns FALSE at EOF (because the underlying InputStream's
+    // available() returns 0 once the pipe is closed), so without the
+    // explicit process.isAlive check the wrapper would spin here
+    // indefinitely after a child crash. mystem is robust enough that this
+    // doesn't trigger in practice, but a segfault or OOM in the child
+    // shouldn't permanently jam the wrapper either.
+    while (!reader.ready() && process.isAlive) {}
 
-    // ...then drain whatever the process emits in this round.
+    // Drain whatever's available. readLine() returns null at EOF; we
+    // stop appending in that case so we don't accidentally emit the
+    // literal string "null" as part of the response.
     val builder = new StringBuilder()
-    while (reader.ready())
-      builder.append(reader.readLine())
+    var atEof = false
+    while (reader.ready() && !atEof) {
+      val line = reader.readLine()
+      if (line == null)
+        atEof = true
+      else
+        builder.append(line)
+    }
+
+    // If the process exited without producing any output, surface that
+    // as a Failure (via the surrounding Try) rather than returning an
+    // empty string — MyStem3.analyze would otherwise interpret that as
+    // a successful empty analysis and skip the FailSafe restart path.
+    if (builder.isEmpty && (atEof || !process.isAlive)) {
+      throw new java.io.IOException(
+        "process exited before producing any response"
+      )
+    }
+
     builder.toString()
   }
 

--- a/src/test/scala/ru/stachek66/nlp/mystem/holding/CommunicationTest.scala
+++ b/src/test/scala/ru/stachek66/nlp/mystem/holding/CommunicationTest.scala
@@ -14,8 +14,7 @@ import ru.stachek66.nlp.mystem.model.Info
 class CommunicationTest extends AnyFunSuite {
 
   /** Trivial in-memory stub so we don't need a real subprocess. */
-  private class StubMyStem(echo: Request => Response = r => Response(Vector.empty))
-      extends MyStem {
+  private class StubMyStem(echo: Request => Response = r => Response(Vector.empty)) extends MyStem {
     override def analyze(request: Request): Response = echo(request)
   }
 

--- a/src/test/scala/ru/stachek66/nlp/mystem/holding/CommunicationTest.scala
+++ b/src/test/scala/ru/stachek66/nlp/mystem/holding/CommunicationTest.scala
@@ -1,0 +1,134 @@
+package ru.stachek66.nlp.mystem.holding
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import ru.stachek66.nlp.mystem.model.Info
+
+/** Direct, in-process tests for the parts of [[MyStem]] /
+  * [[MyStemApplicationException]] that don't need a real binary. The
+  * end-to-end behavior is covered by [[MyStem3IntegrationTest]] when a
+  * binary is provided; the contract pinned here is the input/output
+  * machinery around the subprocess call, which is otherwise easy to
+  * regress unnoticed.
+  */
+class CommunicationTest extends AnyFunSuite {
+
+  /** Trivial in-memory stub so we don't need a real subprocess. */
+  private class StubMyStem(echo: Request => Response = r => Response(Vector.empty))
+      extends MyStem {
+    override def analyze(request: Request): Response = echo(request)
+  }
+
+  // -- MyStem.normalize ---------------------------------------------------
+
+  test("normalize replaces a single newline with a space") {
+    val m = new StubMyStem()
+    assert(m.normalize("foo\nbar") === "foo bar")
+  }
+
+  test("normalize replaces every newline, not just the first") {
+    // Why this matters: mystem speaks one-request-per-line over stdin. If
+    // any `\n` survives in the request text, mystem will treat the
+    // remainder as a brand-new request and the response stream desyncs.
+    // A "first newline only" implementation would limp along on most
+    // inputs and explode on multi-paragraph ones.
+    val m = new StubMyStem()
+    assert(m.normalize("a\nb\nc\nd") === "a b c d")
+  }
+
+  test("normalize on a string with no newline is identity") {
+    val m = new StubMyStem()
+    val text = "никаких переносов строк"
+    assert(m.normalize(text) === text)
+  }
+
+  test("normalize preserves carriage returns (does NOT touch \\r)") {
+    // Pinning current behavior: the protocol delimiter is `\n` only, and
+    // mystem itself handles bare CRs in input. If we ever decide to strip
+    // CRs too, this test forces that change to be intentional.
+    val m = new StubMyStem()
+    assert(m.normalize("foo\rbar") === "foo\rbar")
+  }
+
+  test("normalize handles empty input") {
+    val m = new StubMyStem()
+    assert(m.normalize("") === "")
+  }
+
+  test("normalize accepts long input without truncation") {
+    // No length cap is documented; pin that defensively.
+    val m = new StubMyStem()
+    val long = ("слово\n" * 1000).stripSuffix("\n")
+    val out = m.normalize(long)
+    assert(out.length === long.length)
+    assert(!out.contains('\n'), "every newline must be replaced")
+  }
+
+  // -- MyStemApplicationException ----------------------------------------
+
+  test("MyStemApplicationException carries the original cause") {
+    // We need callers to be able to switch on `e.getCause` to distinguish
+    // closed-state errors (IllegalStateException), I/O errors, etc. — so
+    // the cause has to survive the wrap.
+    val cause = new IllegalStateException("the wrapped reason")
+    val ex = new MyStemApplicationException(cause)
+    assert(ex.getCause eq cause, "cause must be the exact same object, not a copy")
+    assert(ex.getCause.isInstanceOf[IllegalStateException])
+  }
+
+  test("MyStemApplicationException's message mirrors the cause's message") {
+    // Convenience: when the exception is logged or printed without
+    // unwrapping, the user should still see what went wrong.
+    val cause = new RuntimeException("subprocess died")
+    val ex = new MyStemApplicationException(cause)
+    assert(ex.getMessage === "subprocess died")
+  }
+
+  test("MyStemApplicationException on a null cause has a null message and survives toString") {
+    // Defensive: the wrapper handles `null` so callers don't NPE on edge
+    // cases like a destroy-during-syncRequest race that leaves the Try
+    // failure with a null cause.
+    val ex = new MyStemApplicationException(null)
+    assert(ex.getCause === null)
+    assert(ex.getMessage === null)
+    // Most importantly, toString must not blow up.
+    assert(ex.toString !== null)
+  }
+
+  test("MyStemApplicationException is a checked exception (extends java.lang.Exception)") {
+    // The reason it's checked: Java callers should be forced to handle it
+    // (or declare it). If a future refactor accidentally extends
+    // RuntimeException, Java users would silently miss the failure.
+    val ex = new MyStemApplicationException(new RuntimeException("x"))
+    assert(ex.isInstanceOf[java.lang.Exception])
+    // Reflection avoids "fruitless type test" lint when scalac can prove
+    // the unchecked path is statically impossible — we still want a
+    // runtime-observable assertion in case the class hierarchy changes.
+    assert(
+      !classOf[RuntimeException].isAssignableFrom(classOf[MyStemApplicationException]),
+      "must NOT be unchecked"
+    )
+  }
+
+  // -- MyStem.close default ------------------------------------------------
+
+  test("MyStem.close has a no-op default for trait implementers") {
+    // Pinning this for future implementers who don't own a subprocess —
+    // they shouldn't have to override close() just to say "nothing to do".
+    val m = new StubMyStem()
+    m.close()
+    m.close() // multiple calls fine
+  }
+
+  // -- Response (a couple of fast in-process checks) ----------------------
+
+  test("Response is a value-equality case class") {
+    // Sanity: the wrapper relies on case-class semantics for diffing
+    // analysis results in tests.
+    val a = Response(Vector(Info("x", Some("x"), "")))
+    val b = Response(Vector(Info("x", Some("x"), "")))
+    assert(a === b)
+    val c = Response(Vector(Info("y", Some("y"), "")))
+    assert(a !== c)
+  }
+}

--- a/src/test/scala/ru/stachek66/nlp/mystem/holding/FactoryTest.scala
+++ b/src/test/scala/ru/stachek66/nlp/mystem/holding/FactoryTest.scala
@@ -1,0 +1,84 @@
+package ru.stachek66.nlp.mystem.holding
+
+import java.io.File
+
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Tests for [[Factory]] paths that don't require network access or a real
+  * mystem binary. The end-to-end happy path (download + unpack + spawn) is
+  * exercised by [[MyStem3IntegrationTest]] when a binary is provided; here
+  * we cover the version-validation logic and custom-executable handling.
+  */
+class FactoryTest extends AnyFunSuite {
+
+  // -- Unsupported versions ----------------------------------------------
+
+  test("newMyStem with an unsupported version returns Failure(NotImplementedError)") {
+    // The earlier mystem 1.x / 2.x binaries used a different output format
+    // (one-token-per-line, no JSON) that this wrapper does not parse. We
+    // refuse to instantiate rather than letting a user discover the
+    // mismatch via mojibake output. Failure is wrapped in `Try` so callers
+    // can branch on it without a try/catch.
+    val factory = new Factory()
+    // Use a custom executable so we don't try to download anything during
+    // the test — we want the version check to fail BEFORE I/O.
+    val fakeBinary = File.createTempFile("factorytest-fake-", ".bin")
+    fakeBinary.deleteOnExit()
+    val _ = fakeBinary.setExecutable(true)
+
+    val result = factory.newMyStem("2.0", Some(fakeBinary))
+    assert(result.isFailure, "result must be Failure for unsupported version")
+    val ex = result.failed.get
+    assert(
+      ex.isInstanceOf[NotImplementedError],
+      s"expected NotImplementedError, got ${ex.getClass.getName}: ${ex.getMessage}"
+    )
+    assert(
+      ex.getMessage.contains("2.0"),
+      s"error must name the offending version. message: ${ex.getMessage}"
+    )
+  }
+
+  test("newMyStem with an arbitrary garbage version is also rejected") {
+    val factory = new Factory()
+    val fakeBinary = File.createTempFile("factorytest-fake-", ".bin")
+    fakeBinary.deleteOnExit()
+    val _ = fakeBinary.setExecutable(true)
+
+    val result = factory.newMyStem("not-a-version", Some(fakeBinary))
+    assert(result.isFailure)
+    assert(result.failed.get.isInstanceOf[NotImplementedError])
+  }
+
+  // -- Supported versions reach process spawn ----------------------------
+
+  test("newMyStem with a supported version and a non-mystem binary still constructs (process spawn is lazy-ish)") {
+    // Pin: the constructor of FailSafeExternalProcessServer DOES start the
+    // process eagerly (via the wrapped ExternalProcessServer), so a totally
+    // bogus binary path may surface a Failure here. We use /bin/cat (which
+    // exists on every CI runner Linux/macOS) as a stand-in: it spawns,
+    // doesn't crash, and we never call analyze() — we just verify the
+    // happy-path version routing works. Skipped on hosts without it.
+    assume(new File("/bin/cat").canExecute, "needs /bin/cat")
+    val factory = new Factory(parsingOptions = "")
+    val result = factory.newMyStem("3.1", Some(new File("/bin/cat")))
+    assert(result.isSuccess, s"expected Success, got $result")
+    val mystem = result.get
+    try assert(mystem.isInstanceOf[MyStem3], "supported version must yield MyStem3")
+    finally mystem.close()
+  }
+
+  test("the parsingOptions argument is appended to the command line") {
+    // The default `Factory()` constructor uses `-igd --eng-gr --format
+    // json --weight`. Other callers can override; pin that the override
+    // is actually used (otherwise mystem would default to its own
+    // text-output format and the wrapper's JSON parser would break).
+    assume(new File("/bin/cat").canExecute, "needs /bin/cat")
+    val factory = new Factory(parsingOptions = "--my-custom-flag")
+    // Even with bogus flags, /bin/cat will accept and ignore them on its
+    // command line for the purposes of starting up.
+    val result = factory.newMyStem("3.1", Some(new File("/bin/cat")))
+    assert(result.isSuccess)
+    result.get.close()
+  }
+}

--- a/src/test/scala/ru/stachek66/nlp/mystem/holding/FactoryTest.scala
+++ b/src/test/scala/ru/stachek66/nlp/mystem/holding/FactoryTest.scala
@@ -81,4 +81,98 @@ class FactoryTest extends AnyFunSuite {
     assert(result.isSuccess)
     result.get.close()
   }
+
+  // -- isCorrectVersion: cached-binary version detection -----------------
+
+  /** Build a tiny shell script that prints `body` on `-v` and exits 0,
+    * mimicking what real mystem does for `mystem -v`. The script is
+    * marked executable and self-deleting on JVM exit.
+    */
+  private def fakeBinaryPrinting(body: String): File = {
+    val f = File.createTempFile("factory-fake-mystem-", ".sh")
+    f.deleteOnExit()
+    val script =
+      s"""#!/bin/sh
+         |# Fake mystem binary for FactoryTest.isCorrectVersion.
+         |# Real mystem prints its version on -v; we mimic that
+         |# behaviour irrespective of arguments to keep the test simple.
+         |echo "${body.replace("\"", "\\\"")}"
+         |""".stripMargin
+    java.nio.file.Files.write(f.toPath, script.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+    val _ = f.setExecutable(true)
+    f
+  }
+
+  test("isCorrectVersion returns true when the binary's version output contains the requested version") {
+    // Real mystem prints something like
+    //   Yandex Mystem 3.1 (libmystem 3.1, build 2017-04-11)
+    // We only need substring containment on the version we asked for.
+    assume(new java.io.File("/bin/sh").canExecute, "needs /bin/sh")
+    val factory = new Factory()
+    val fake = fakeBinaryPrinting("Yandex Mystem 3.1 (linux64)")
+    assert(factory.isCorrectVersion(fake, "3.1"))
+  }
+
+  test("isCorrectVersion returns false when the binary prints a DIFFERENT version") {
+    // The trigger for the delete-and-refetch path: a stale binary from
+    // an older or unrelated install. Pin: we DO refuse to reuse it.
+    assume(new java.io.File("/bin/sh").canExecute, "needs /bin/sh")
+    val factory = new Factory()
+    val fake = fakeBinaryPrinting("Yandex Mystem 9.9.9 (custom)")
+    assert(!factory.isCorrectVersion(fake, "3.1"))
+  }
+
+  test("isCorrectVersion returns false when the binary cannot be executed (broken cache file)") {
+    // Cached file exists but isn't executable — common after a partial
+    // download or a tarball that was extracted with the wrong umask.
+    // Falling back to "version cannot be confirmed → re-fetch" is the
+    // right move; the alternative is a confusing crash much later.
+    val factory = new Factory()
+    val notExec = File.createTempFile("factory-not-exec-", ".bin")
+    notExec.deleteOnExit()
+    java.nio.file.Files.write(notExec.toPath, "garbage".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+    // Deliberately do NOT call setExecutable(true).
+    assert(!factory.isCorrectVersion(notExec, "3.1"))
+  }
+
+  test("isCorrectVersion returns false on a non-existent binary path") {
+    val factory = new Factory()
+    val ghost = new File("/tmp/nonexistent-mystem-binary-zzyzx-" + System.nanoTime())
+    assert(!ghost.exists())
+    assert(!factory.isCorrectVersion(ghost, "3.1"))
+  }
+
+  test("isCorrectVersion does substring matching on the version line") {
+    // Real output isn't equal to the version string, it CONTAINS it.
+    // Pin that we do plain `String.contains` and not exact equality —
+    // "3.1" must match "Yandex Mystem 3.1 (...)".
+    assume(new java.io.File("/bin/sh").canExecute, "needs /bin/sh")
+    val factory = new Factory()
+    val fake = fakeBinaryPrinting("I am Yandex Mystem version 3.1, hello!")
+    assert(factory.isCorrectVersion(fake, "3.1"))
+  }
+
+  test("isCorrectVersion treats the version arg as plaintext, not a regex") {
+    // If we ever swapped contains() for a regex match, "3.1" would
+    // suddenly match "3X1" too because `.` is "any character" in regex.
+    // Pin that swap as an intentional change rather than an accident.
+    assume(new java.io.File("/bin/sh").canExecute, "needs /bin/sh")
+    val factory = new Factory()
+    val fake = fakeBinaryPrinting("Mystem 3X1")
+    assert(!factory.isCorrectVersion(fake, "3.1"))
+  }
+
+  test("isCorrectVersion returns false when the binary exits non-zero") {
+    // `(cmd).!!` throws on a non-zero exit code (it's the
+    // "throw-on-failure" sibling of `.!`). Our Try/Failure branch
+    // catches that and returns false — the binary is unusable, treat
+    // it as a wrong-version cache to be replaced.
+    assume(new java.io.File("/bin/sh").canExecute, "needs /bin/sh")
+    val factory = new Factory()
+    val f = File.createTempFile("factory-exit-1-", ".sh")
+    f.deleteOnExit()
+    java.nio.file.Files.write(f.toPath, "#!/bin/sh\nexit 1\n".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+    val _ = f.setExecutable(true)
+    assert(!factory.isCorrectVersion(f, "3.1"))
+  }
 }

--- a/src/test/scala/ru/stachek66/nlp/mystem/holding/MyStem3IntegrationTest.scala
+++ b/src/test/scala/ru/stachek66/nlp/mystem/holding/MyStem3IntegrationTest.scala
@@ -4,6 +4,7 @@ import java.io.File
 
 import org.scalatest.funsuite.AnyFunSuite
 
+import ru.stachek66.nlp.mystem.model.{AdjectiveForms, Number, POS}
 import ru.stachek66.nlp.mystem.parsing.GrammarInfoParsing
 
 /** End-to-end integration test that drives the actual `mystem` binary.
@@ -140,17 +141,44 @@ class MyStem3IntegrationTest extends AnyFunSuite {
     )
   }
 
-  // -- Reality check on the parens-ambiguity known limitation -------------
+  // -- Parens-pipe alternatives in real output ---------------------------
 
-  test("[integration] real mystem output exposes the parens-ambiguity gr format we don't parse") {
-    // Documentation-as-test. The user runs `mystem -igd --eng-gr --format
-    // json --weight` and the `gr` field commonly looks like
-    //   "A,plen=(acc,sg,m,anim|gen,sg,m|gen,sg,n)"
-    // GrammarInfoParsing.toGrammarInfo can't handle the parens; this test
-    // pins that the format actually does occur in real output AND that
-    // the parser deliberately throws on it. If mystem's output ever
-    // changes shape (or the parser learns to handle parens), this test
-    // forces an intentional update.
+  test("[integration] real verb output with `indic`/`praet` aliases parses every dimension") {
+    // Pre-fix, real verb output threw NoSuchElementException on `indic`
+    // (mystem's wire form for indicative mood; our enum had `ind`) and
+    // `praet` (past tense; our enum had `past`). We added alias
+    // canonicalisation so real output is parseable. End-to-end test.
+    assumeBinary()
+    withMystem { m =>
+      // Present-tense, 1st-person-singular indicative.
+      val present = m.analyze(Request("читаю")).info.toVector
+      val rawP = present.head.rawResponse
+      val grP = "\"gr\":\"([^\"]+)\"".r.findFirstMatchIn(rawP).map(_.group(1)).get
+      val giP = GrammarInfoParsing.toGrammarInfo(grP)
+      assert(giP.pos === Set(POS.V), s"gr=$grP")
+      assert(giP.verbFormInfo.contains(ru.stachek66.nlp.mystem.model.VerbForms.indicativeMood),
+        s"`indic` alias must map to indicativeMood, gr=$grP, parsed=$giP")
+      assert(giP.person.nonEmpty, s"verb in 1p form must have a person tag, gr=$grP")
+
+      // Past-tense form, exercises `praet` alias.
+      val past = m.analyze(Request("мыл")).info.toVector
+      val rawPast = past.find(_.lex.contains("мыть")).get.rawResponse
+      val grPast = "\"gr\":\"([^\"]+)\"".r.findFirstMatchIn(rawPast).map(_.group(1)).get
+      val giPast = GrammarInfoParsing.toGrammarInfo(grPast)
+      assert(giPast.tense === Set(ru.stachek66.nlp.mystem.model.Tense.past),
+        s"`praet` alias must map to Tense.past, gr=$grPast, parsed=$giPast")
+    }
+  }
+
+  test("[integration] real mystem parens-pipe gr fields parse into multiple GrammarInfos") {
+    // The lemma "тестового" has three mutually exclusive parses:
+    //   acc.sg.m.anim | gen.sg.m | gen.sg.n
+    // mystem emits this as a parens-pipe `gr` string, which used to throw
+    // NoSuchElementException because `(acc` was looked up as a tag. Now
+    // toGrammarInfos splits on `|` and returns one GrammarInfo per
+    // alternative. We don't depend on a fixed alternative count (mystem
+    // could conceivably tighten or expand the analysis in a future
+    // release); we DO depend on every alternative being well-formed.
     assumeBinary()
     withMystem { m =>
       val infos = m.analyze(Request("тестового")).info.toVector
@@ -159,9 +187,22 @@ class MyStem3IntegrationTest extends AnyFunSuite {
       val grRegex = "\"gr\":\"([^\"]+)\"".r
       val gr = grRegex.findFirstMatchIn(raw).map(_.group(1)).getOrElse(fail(s"no gr field in $raw"))
 
-      intercept[NoSuchElementException] {
-        GrammarInfoParsing.toGrammarInfo(gr)
+      val parsed = GrammarInfoParsing.toGrammarInfos(gr)
+      assert(parsed.size >= 2, s"expected ≥2 alternatives in real output `$gr`, got ${parsed.size}")
+
+      // Every alternative shares the prefix-derived dimensions: POS=A,
+      // adjFormInfo=plen. Verifying these holds across alternatives proves
+      // the prefix was applied to each.
+      parsed.foreach { gi =>
+        assert(gi.pos === Set(POS.A))
+        assert(gi.adjFormInfo === Set(AdjectiveForms.plen))
+        assert(gi.number === Set(Number.singular))
       }
+
+      // No alternative can have empty `case` — every parse must commit to
+      // one of acc/gen/etc. This catches a class of bug where the prefix
+      // is applied but the alternative-specific tags are dropped.
+      parsed.foreach(gi => assert(gi.`case`.nonEmpty, s"alternative with empty case: $gi"))
     }
   }
 }

--- a/src/test/scala/ru/stachek66/nlp/mystem/holding/MyStem3IntegrationTest.scala
+++ b/src/test/scala/ru/stachek66/nlp/mystem/holding/MyStem3IntegrationTest.scala
@@ -156,8 +156,10 @@ class MyStem3IntegrationTest extends AnyFunSuite {
       val grP = "\"gr\":\"([^\"]+)\"".r.findFirstMatchIn(rawP).map(_.group(1)).get
       val giP = GrammarInfoParsing.toGrammarInfo(grP)
       assert(giP.pos === Set(POS.V), s"gr=$grP")
-      assert(giP.verbFormInfo.contains(ru.stachek66.nlp.mystem.model.VerbForms.indicativeMood),
-        s"`indic` alias must map to indicativeMood, gr=$grP, parsed=$giP")
+      assert(
+        giP.verbFormInfo.contains(ru.stachek66.nlp.mystem.model.VerbForms.indicativeMood),
+        s"`indic` alias must map to indicativeMood, gr=$grP, parsed=$giP"
+      )
       assert(giP.person.nonEmpty, s"verb in 1p form must have a person tag, gr=$grP")
 
       // Past-tense form, exercises `praet` alias.
@@ -165,8 +167,10 @@ class MyStem3IntegrationTest extends AnyFunSuite {
       val rawPast = past.find(_.lex.contains("мыть")).get.rawResponse
       val grPast = "\"gr\":\"([^\"]+)\"".r.findFirstMatchIn(rawPast).map(_.group(1)).get
       val giPast = GrammarInfoParsing.toGrammarInfo(grPast)
-      assert(giPast.tense === Set(ru.stachek66.nlp.mystem.model.Tense.past),
-        s"`praet` alias must map to Tense.past, gr=$grPast, parsed=$giPast")
+      assert(
+        giPast.tense === Set(ru.stachek66.nlp.mystem.model.Tense.past),
+        s"`praet` alias must map to Tense.past, gr=$grPast, parsed=$giPast"
+      )
     }
   }
 

--- a/src/test/scala/ru/stachek66/nlp/mystem/parsing/GrammarInfoParsingTest.scala
+++ b/src/test/scala/ru/stachek66/nlp/mystem/parsing/GrammarInfoParsingTest.scala
@@ -41,14 +41,13 @@ class GrammarInfoParsingTest extends AnyFunSuite {
     assert(gi.other.isEmpty)
   }
 
-  test("verb: V,ipf,intr=praes,sg,ind routes correctly") {
-    // The `1p` tag (Person.p1) is documented separately below; we omit it
-    // here because GrammarInfo does not surface a `person` field.
-    val gi = toGrammarInfo("V,ipf,intr=praes,sg,ind")
+  test("verb: V,ipf,intr=praes,sg,1p,ind routes correctly to every dimension including person") {
+    val gi = toGrammarInfo("V,ipf,intr=praes,sg,1p,ind")
     assert(gi.pos === Set(POS.V))
     assert(gi.aspect === Set(Aspect.imperfective))
     assert(gi.tense === Set(Tense.present))
     assert(gi.number === Set(Number.singular))
+    assert(gi.person === Set(Person.p1))
     assert(gi.verbFormInfo === Set(VerbForms.intransitive, VerbForms.indicativeMood))
   }
 
@@ -178,8 +177,65 @@ class GrammarInfoParsingTest extends AnyFunSuite {
     assert(missing.isEmpty, s"GrammarMapBuilder is missing: ${missing.mkString(", ")}")
   }
 
-  test("each documented tag in tagToEnumMap maps to the enum it belongs to") {
-    // Catches a class of mistake: a tag accidentally registered under the
+  // -- Wire-format aliases (mystem-3.x ↔ Enumeration name divergence) ---
+
+  test("`indic` (mystem's wire form) parses as VerbForms.indicativeMood") {
+    // mystem 3.x emits `indic` for indicative mood, but our enum was
+    // declared with `Value(\"ind\")` historically. Both must parse.
+    // Without alias support, real verb output throws NoSuchElementException.
+    val gi = toGrammarInfo("V,ipf,intr=inpraes,sg,indic,1p")
+    assert(gi.verbFormInfo.contains(VerbForms.indicativeMood))
+    assert(gi.tense === Set(Tense.inpraes))
+    assert(gi.person === Set(Person.p1))
+  }
+
+  test("`ind` (the canonical Value name) still parses, for backward compat") {
+    val gi = toGrammarInfo("V,ipf,intr=praes,sg,1p,ind")
+    assert(gi.verbFormInfo.contains(VerbForms.indicativeMood))
+  }
+
+  test("`praet` (mystem wire form for past tense) parses as Tense.past") {
+    // Same shape as the indic alias: `Value(\"past\")` historically,
+    // mystem emits `praet` (Latin praeteritum). Real past-tense output
+    // would otherwise throw.
+    val gi = toGrammarInfo("V,ipf,intr=praet,sg,indic,m")
+    assert(gi.tense === Set(Tense.past))
+    assert(gi.gender === Set(Gender.masculine))
+  }
+
+  test("`past` (canonical name) still parses, for backward compat") {
+    val gi = toGrammarInfo("V=past")
+    assert(gi.tense === Set(Tense.past))
+  }
+
+  test("real-world `inpraes,sg,indic,1p` parses every dimension correctly") {
+    // The actual `gr` shape mystem emits for present-tense indicative
+    // verbs like \"иду\" / \"читаю\" / \"играю\". Pinned end-to-end:
+    // tense, number, mood, person all populated correctly with alias
+    // mapping in place.
+    val gi = toGrammarInfo("V,ipf,tran=inpraes,sg,indic,1p")
+    assert(gi.pos === Set(POS.V))
+    assert(gi.aspect === Set(Aspect.imperfective))
+    assert(gi.verbFormInfo === Set(VerbForms.transitive, VerbForms.indicativeMood))
+    assert(gi.tense === Set(Tense.inpraes))
+    assert(gi.number === Set(Number.singular))
+    assert(gi.person === Set(Person.p1))
+  }
+
+  test("alias canonicalisation only rewrites known aliases, not arbitrary tags") {
+    // Pin: canonical(x) is the identity for tags not in the alias map.
+    // Otherwise a future addition to aliases could silently rename
+    // unrelated tags.
+    assert(GrammarMapBuilder.canonical("nom") === "nom")
+    assert(GrammarMapBuilder.canonical("S") === "S")
+    assert(GrammarMapBuilder.canonical("indic") === "ind") // alias
+    assert(GrammarMapBuilder.canonical("praet") === "past") // alias
+    // Unknown tags: canonical() returns them unchanged. The throw on
+    // lookup is the parser's responsibility, not canonical's.
+    assert(GrammarMapBuilder.canonical("nonsense") === "nonsense")
+  }
+
+  test("each documented tag in tagToEnumMap maps to the enum it belongs to") {    // Catches a class of mistake: a tag accidentally registered under the
     // wrong enum (e.g., "nom" landing in Gender instead of Case).
     val expectations = Map(
       "S" -> POS,
@@ -232,31 +288,138 @@ class GrammarInfoParsingTest extends AnyFunSuite {
     }
   }
 
-  // -- Pinned known limitations -------------------------------------------
+  // -- Person field -------------------------------------------------------
 
-  test("known limitation: the `1p`/`2p`/`3p` person tag is recognized but lost") {
-    // Person values exist in tagToEnumMap (verified above) but `GrammarInfo`
-    // has no `person: Set[Person.Value]` field, so the parser drops them
-    // on the floor. This test pins that behavior so any future change that
-    // adds a `person` field is forced to update both production and tests
-    // intentionally.
-    val gi = toGrammarInfo("V,ipf,intr=praes,sg,1p,ind")
-    // No assertion *about* person — there's no field to assert on. The
-    // important assertion is that PARSING didn't throw, since that's
-    // observable from outside.
-    assert(gi.pos === Set(POS.V))
+  test("person tag (`1p`/`2p`/`3p`) populates GrammarInfo.person") {
+    // Used to be a silent-drop bug: tagToEnumMap routed `1p` through Person,
+    // but GrammarInfo had no `person` field for it to land in. Fixed by
+    // adding `person: Set[Person.Value]` and populating it from the same
+    // findByEnum machinery as every other dimension.
+    assert(toGrammarInfo("V,ipf,intr=praes,sg,1p,ind").person === Set(Person.p1))
+    assert(toGrammarInfo("V,ipf,intr=praes,pl,2p,ind").person === Set(Person.p2))
+    assert(toGrammarInfo("V,ipf,intr=praes,sg,3p,ind").person === Set(Person.p3))
   }
 
-  test("known limitation: ambiguity-paren syntax `(a,b|c,d)` is NOT supported") {
-    // Real mystem output with `--weight` looks like
-    //   "S,f,inan=(gen,sg|nom,pl)"
-    // The current parser splits on `[,=]` only, so the parens become
-    // part of the would-be tag (e.g., "(gen") and lookup in
-    // tagToEnumMap throws NoSuchElementException. This is documented
-    // here so a future supporter knows it's a known issue, not an
-    // accidental regression.
+  test("an analysis without a person tag has an empty person set (not null)") {
+    // Negative: the field is `Set` so it had better default to `Set.empty`,
+    // not crash. This pins the case-class default.
+    val noun = toGrammarInfo("S,f,inan=nom,sg")
+    assert(noun.person !== null)
+    assert(noun.person.isEmpty)
+  }
+
+  test("round-trip preserves person across toStringRepresentation → toGrammarInfo") {
+    val original = toGrammarInfo("V,ipf,intr=praes,sg,2p,ind")
+    val round = toGrammarInfo(toStringRepresentation(original))
+    assert(round === original, "structural equality must include the person field")
+    assert(round.person === Set(Person.p2))
+  }
+
+  test("toStringRepresentation includes person tags in its output") {
+    // Sanity check on the serializer: if we forgot to add gi.person to the
+    // concatenation, the round-trip above would still pass for any
+    // GrammarInfo whose person field was empty, but would fail for ones
+    // where it isn't. This test pins the serializer directly.
+    val gi = toGrammarInfo("V,ipf,intr=praes,sg,3p,ind")
+    val emitted = toStringRepresentation(gi)
+    assert(emitted.split(',').contains("3p"), s"toStringRepresentation should emit `3p`, got: $emitted")
+  }
+
+  // -- Parens-pipe alternative-analysis form ------------------------------
+
+  test("toGrammarInfos returns one GrammarInfo per parens-alternative") {
+    // Real mystem output for the lemma "тестового" — three mutually
+    // exclusive parses sharing a common `A,plen=` prefix. Each alternative
+    // gets its own GrammarInfo with the right combination of dimensions;
+    // we verify that the alternatives DON'T cross-contaminate (e.g., the
+    // animacy tag from alt 1 must not leak into alt 2 or alt 3).
+    val infos = toGrammarInfos("A,plen=(acc,sg,m,anim|gen,sg,m|gen,sg,n)")
+    assert(infos.size === 3)
+
+    // Alt 0: accusative, singular, masculine, animate.
+    assert(infos(0).pos === Set(POS.A))
+    assert(infos(0).adjFormInfo === Set(AdjectiveForms.plen))
+    assert(infos(0).`case` === Set(Case.accusative))
+    assert(infos(0).number === Set(Number.singular))
+    assert(infos(0).gender === Set(Gender.masculine))
+    assert(infos(0).animacy === Set(Animacy.animate))
+
+    // Alt 1: genitive, singular, masculine, NO animacy tag.
+    assert(infos(1).`case` === Set(Case.genitive))
+    assert(infos(1).gender === Set(Gender.masculine))
+    assert(infos(1).animacy.isEmpty, "anim must NOT bleed across alternatives")
+
+    // Alt 2: genitive, singular, neuter, NO animacy.
+    assert(infos(2).`case` === Set(Case.genitive))
+    assert(infos(2).gender === Set(Gender.neuter))
+    assert(infos(2).animacy.isEmpty)
+  }
+
+  test("toGrammarInfos with a 2-alternative input") {
+    // Smaller realistic case to verify the parser doesn't only handle
+    // exactly-3 alternatives.
+    val infos = toGrammarInfos("S,f,inan=(gen,sg|nom,pl)")
+    assert(infos.size === 2)
+    assert(infos(0).`case` === Set(Case.genitive) && infos(0).number === Set(Number.singular))
+    assert(infos(1).`case` === Set(Case.nominative) && infos(1).number === Set(Number.plural))
+  }
+
+  test("toGrammarInfos returns a single-element list for non-parens input") {
+    // The shape with no parens in `gr` (mystem omits parens when there's
+    // only one analysis) should still work — we shouldn't make every
+    // caller special-case "is there a paren or not?".
+    val infos = toGrammarInfos("S,f,inan=nom,sg")
+    assert(infos.size === 1)
+    assert(infos.head.pos === Set(POS.S))
+    assert(infos.head.`case` === Set(Case.nominative))
+  }
+
+  test("toGrammarInfos for a bare POS (no `=`) works") {
+    val infos = toGrammarInfos("ADV")
+    assert(infos.size === 1)
+    assert(infos.head.pos === Set(POS.ADV))
+  }
+
+  test("toGrammarInfo (singular) returns the FIRST alternative when input has parens") {
+    // mystem orders alternatives by descending probability, so `.head` is
+    // the most-likely interpretation. Pinning this so a future "return
+    // average" or "return union" change has to be intentional.
+    val gi = toGrammarInfo("A,plen=(acc,sg,m,anim|gen,sg,m|gen,sg,n)")
+    val infos = toGrammarInfos("A,plen=(acc,sg,m,anim|gen,sg,m|gen,sg,n)")
+    assert(gi === infos.head)
+    assert(gi.`case` === Set(Case.accusative))
+    assert(gi.animacy === Set(Animacy.animate))
+  }
+
+  test("the fixed prefix is correctly applied to every alternative") {
+    // Regression for an off-by-one in prefix construction that would have
+    // produced a malformed combined string for alt 2 onwards. Every
+    // alternative should preserve the `A` POS and the `plen` adjective
+    // form (which both come from the prefix).
+    val infos = toGrammarInfos("A,plen=(acc,sg,m,anim|gen,sg,m|gen,sg,n)")
+    infos.foreach { gi =>
+      assert(gi.pos === Set(POS.A), "POS lost on later alternative")
+      assert(gi.adjFormInfo === Set(AdjectiveForms.plen), "adjFormInfo lost on later alternative")
+      assert(gi.number === Set(Number.singular), "number tag from variable part lost")
+    }
+  }
+
+  test("empty parens `S=()` yields a single GrammarInfo with just the prefix tags") {
+    // Defensible: the prefix has its own meaning, the parens are the
+    // alternative slot. Empty alternatives → one trivial alternative.
+    val infos = toGrammarInfos("A,plen=()")
+    assert(infos.size === 1)
+    assert(infos.head.pos === Set(POS.A))
+    assert(infos.head.adjFormInfo === Set(AdjectiveForms.plen))
+    assert(infos.head.`case`.isEmpty, "no case tag in input → empty case set")
+  }
+
+  test("a stray unknown tag inside parens fails the whole parse, not silently") {
+    // Same fail-loud contract as the non-parens path: an unrecognized tag
+    // means we're looking at output we don't understand, which is a build-
+    // time signal, not something to swallow at runtime.
     intercept[NoSuchElementException] {
-      toGrammarInfo("S,f,inan=(gen,sg|nom,pl)")
+      toGrammarInfos("A,plen=(acc,sg|UNKNOWN_TAG,sg)")
     }
   }
 }

--- a/src/test/scala/ru/stachek66/nlp/mystem/parsing/GrammarInfoParsingTest.scala
+++ b/src/test/scala/ru/stachek66/nlp/mystem/parsing/GrammarInfoParsingTest.scala
@@ -235,7 +235,7 @@ class GrammarInfoParsingTest extends AnyFunSuite {
     assert(GrammarMapBuilder.canonical("nonsense") === "nonsense")
   }
 
-  test("each documented tag in tagToEnumMap maps to the enum it belongs to") {    // Catches a class of mistake: a tag accidentally registered under the
+  test("each documented tag in tagToEnumMap maps to the enum it belongs to") { // Catches a class of mistake: a tag accidentally registered under the
     // wrong enum (e.g., "nom" landing in Gender instead of Case).
     val expectations = Map(
       "S" -> POS,

--- a/src/test/scala/ru/stachek66/tools/DownloaderTest.scala
+++ b/src/test/scala/ru/stachek66/tools/DownloaderTest.scala
@@ -1,0 +1,94 @@
+package ru.stachek66.tools
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import org.apache.commons.io.FileUtils
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Tests for [[Downloader]] using `file://` URLs so we don't depend on
+  * mystem's CDN — the network is exactly the variability we want to
+  * remove from CI. The contract being tested is the same regardless of
+  * URL scheme (since `Downloader` just delegates to commons-io's
+  * URL-to-file copier).
+  */
+class DownloaderTest extends AnyFunSuite {
+
+  /** Create a temp file and write the given content to it; return the URL. */
+  private def fileUrl(content: String): java.net.URL = {
+    val f = File.createTempFile("downloader-source-", ".bin")
+    f.deleteOnExit()
+    Files.write(f.toPath, content.getBytes(StandardCharsets.UTF_8))
+    f.toURI.toURL
+  }
+
+  test("downloadBinaryFile copies the URL contents to the destination byte-for-byte") {
+    val src = fileUrl("hello, мир!")
+    val dst = File.createTempFile("downloader-dst-", ".bin")
+    dst.deleteOnExit()
+
+    val returned = Downloader.downloadBinaryFile(src, dst)
+    assert(returned === dst, "downloadBinaryFile should return its destination File")
+
+    val written = FileUtils.readFileToString(dst, StandardCharsets.UTF_8)
+    assert(written === "hello, мир!")
+  }
+
+  test("downloadBinaryFile creates missing parent directories of the destination") {
+    // Why: the production caller writes to `~/.local/bin/mystem`, which
+    // typically exists, but custom destinations (or first-run on a fresh
+    // user account) don't. The wrapper should not require the user to
+    // pre-create the directory — that's why `mkdirs()` is in
+    // Downloader and not in the caller.
+    val src = fileUrl("body")
+
+    // Build a destination with TWO levels of missing parent directories.
+    val tmpRoot = Files.createTempDirectory("downloader-test-")
+    val deep = tmpRoot.resolve("does-not-exist-yet/and-this-too/output.bin").toFile
+    assert(!deep.getParentFile.exists(), "test setup: parent must not exist before the call")
+
+    val returned = Downloader.downloadBinaryFile(src, deep)
+    assert(returned.exists(), "destination should exist after downloadBinaryFile returns")
+    assert(returned.getParentFile.exists(), "parent directory should have been created")
+    assert(FileUtils.readFileToString(deep, StandardCharsets.UTF_8) === "body")
+
+    // Best-effort cleanup so test runs don't pile up tmp dirs.
+    val _ = deep.delete()
+    val _2 = deep.getParentFile.delete()
+    val _3 = deep.getParentFile.getParentFile.delete()
+    val _4 = tmpRoot.toFile.delete()
+  }
+
+  test("downloadBinaryFile is idempotent — calling it twice overwrites") {
+    // If a previous run left a stale binary at the destination, the next
+    // run should freshen it rather than refuse. That's how Factory's
+    // version-mismatch path works (delete + re-download).
+    val src1 = fileUrl("first run")
+    val src2 = fileUrl("second run")
+    val dst = File.createTempFile("downloader-overwrite-", ".bin")
+    dst.deleteOnExit()
+
+    Downloader.downloadBinaryFile(src1, dst)
+    assert(FileUtils.readFileToString(dst, StandardCharsets.UTF_8) === "first run")
+
+    Downloader.downloadBinaryFile(src2, dst)
+    assert(FileUtils.readFileToString(dst, StandardCharsets.UTF_8) === "second run")
+  }
+
+  test("downloadBinaryFile surfaces a recognisable error when the URL is unreachable") {
+    // `file:///nonexistent/...` raises FileNotFoundException via
+    // commons-io. We don't insist on the exact exception type — different
+    // commons-io versions wrap it differently — but we DO insist that the
+    // failure isn't silent and the destination wasn't half-created.
+    val src = new java.net.URI("file:///definitely/not/a/real/path/abcxyz123.bin").toURL
+    val dst = File.createTempFile("downloader-bad-source-", ".bin")
+    val _ = dst.delete() // start with destination NOT existing
+    dst.deleteOnExit()
+
+    val ex = intercept[Throwable](Downloader.downloadBinaryFile(src, dst))
+    val msg = ex.getMessage
+    assert(msg !== null, s"unreachable-source exception must have a message; class=${ex.getClass.getName}")
+    assert(!dst.exists() || dst.length() === 0L, "no half-written destination on failure")
+  }
+}

--- a/src/test/scala/ru/stachek66/tools/TarGzTest.scala
+++ b/src/test/scala/ru/stachek66/tools/TarGzTest.scala
@@ -50,6 +50,53 @@ class TarGzTest extends AnyFunSuite {
     assert(msg.nonEmpty)
   }
 
+  test("unpacking an EMPTY tar.gz surfaces an `Archive is empty` IOException") {
+    val tgz = File.createTempFile("mystem-scala-tgz-empty-", ".tar.gz")
+    tgz.deleteOnExit()
+    val gzip = new GZIPOutputStream(new FileOutputStream(tgz))
+    val tar = new TarArchiveOutputStream(gzip)
+    try {
+      tar.finish()
+    } finally {
+      tar.close()
+      gzip.close()
+    }
+
+    val dst = File.createTempFile("mystem-scala-tgz-empty-out-", ".out")
+    dst.deleteOnExit()
+
+    val ex = intercept[IOException](TarGz.unpack(tgz, dst))
+    assert(
+      ex.getMessage.toLowerCase.contains("empty"),
+      s"expected `empty`-flavoured message, got: ${ex.getMessage}"
+    )
+  }
+
+  test("unpacking a tar.gz whose first entry is a DIRECTORY raises an IOException") {
+    val tgz = File.createTempFile("mystem-scala-tgz-dir-first-", ".tar.gz")
+    tgz.deleteOnExit()
+    val gzip = new GZIPOutputStream(new FileOutputStream(tgz))
+    val tar = new TarArchiveOutputStream(gzip)
+    try {
+      val dir = new TarArchiveEntry("subdir/", true)
+      tar.putArchiveEntry(dir)
+      tar.closeArchiveEntry()
+    } finally {
+      tar.finish()
+      tar.close()
+      gzip.close()
+    }
+
+    val dst = File.createTempFile("mystem-scala-tgz-dir-first-out-", ".out")
+    dst.deleteOnExit()
+
+    val ex = intercept[IOException](TarGz.unpack(tgz, dst))
+    assert(
+      ex.getMessage.toLowerCase.contains("directory"),
+      s"expected `directory`-flavoured message, got: ${ex.getMessage}"
+    )
+  }
+
   // -- Helpers ------------------------------------------------------------
 
   private def readAllText(f: File): String = {

--- a/src/test/scala/ru/stachek66/tools/TarGzTest.scala
+++ b/src/test/scala/ru/stachek66/tools/TarGzTest.scala
@@ -55,9 +55,8 @@ class TarGzTest extends AnyFunSuite {
     tgz.deleteOnExit()
     val gzip = new GZIPOutputStream(new FileOutputStream(tgz))
     val tar = new TarArchiveOutputStream(gzip)
-    try {
-      tar.finish()
-    } finally {
+    try tar.finish()
+    finally {
       tar.close()
       gzip.close()
     }

--- a/src/test/scala/ru/stachek66/tools/ZipTest.scala
+++ b/src/test/scala/ru/stachek66/tools/ZipTest.scala
@@ -81,7 +81,8 @@ class ZipTest extends AnyFunSuite {
     val zip = File.createTempFile("mystem-scala-zip-empty-", ".zip")
     zip.deleteOnExit()
     val out = new ZipArchiveOutputStream(new FileOutputStream(zip))
-    try { out.finish() } finally { out.close() }
+    try out.finish()
+    finally out.close()
 
     val dst = File.createTempFile("mystem-scala-zip-empty-out-", ".out")
     dst.deleteOnExit()

--- a/src/test/scala/ru/stachek66/tools/ZipTest.scala
+++ b/src/test/scala/ru/stachek66/tools/ZipTest.scala
@@ -73,6 +73,53 @@ class ZipTest extends AnyFunSuite {
     assert(msg.nonEmpty, "the exception must explain itself")
   }
 
+  test("unpacking an EMPTY zip surfaces an `Archive is empty` IOException") {
+    // Edge case from Decompressor.copyUncompressedAndClose: getNextEntry
+    // returning null means we have a structurally-valid but empty
+    // archive. We refuse rather than silently producing a 0-byte output
+    // file the user might mistake for a successful extract.
+    val zip = File.createTempFile("mystem-scala-zip-empty-", ".zip")
+    zip.deleteOnExit()
+    val out = new ZipArchiveOutputStream(new FileOutputStream(zip))
+    try { out.finish() } finally { out.close() }
+
+    val dst = File.createTempFile("mystem-scala-zip-empty-out-", ".out")
+    dst.deleteOnExit()
+
+    val ex = intercept[IOException](Zip.unpack(zip, dst))
+    assert(
+      ex.getMessage.toLowerCase.contains("empty"),
+      s"expected `empty`-flavoured message, got: ${ex.getMessage}"
+    )
+  }
+
+  test("unpacking a zip whose first entry is a DIRECTORY raises an IOException") {
+    // The mystem release zip ships a single executable as its first entry.
+    // If a future packaging change moves the executable behind a
+    // directory entry, we want a loud failure rather than silently
+    // producing a directory-named output file. Pin the contract.
+    val zip = File.createTempFile("mystem-scala-zip-dir-first-", ".zip")
+    zip.deleteOnExit()
+    val out = new ZipArchiveOutputStream(new FileOutputStream(zip))
+    try {
+      val dirEntry = new ZipArchiveEntry("subdir/")
+      out.putArchiveEntry(dirEntry)
+      out.closeArchiveEntry()
+    } finally {
+      out.finish()
+      out.close()
+    }
+
+    val dst = File.createTempFile("mystem-scala-zip-dir-first-out-", ".out")
+    dst.deleteOnExit()
+
+    val ex = intercept[IOException](Zip.unpack(zip, dst))
+    assert(
+      ex.getMessage.toLowerCase.contains("directory"),
+      s"expected `directory`-flavoured message, got: ${ex.getMessage}"
+    )
+  }
+
   // -- Helpers ------------------------------------------------------------
 
   private def readAllText(f: File): String = {

--- a/src/test/scala/ru/stachek66/tools/external/ExternalProcessServerTest.scala
+++ b/src/test/scala/ru/stachek66/tools/external/ExternalProcessServerTest.scala
@@ -117,11 +117,12 @@ class ExternalProcessServerTest extends AnyFunSuite {
     f
   }
 
-  private def hasPython3: Boolean =
-    scala.util.Try {
+  private def hasPython3: Boolean = scala.util
+    .Try {
       val p = new ProcessBuilder("python3", "--version").redirectErrorStream(true).start()
       p.waitFor() == 0
-    }.getOrElse(false)
+    }
+    .getOrElse(false)
 
   test("syncRequest writes a line to stdin and returns the line the process emits") {
     assume(isUnixLike && hasPython3, "needs python3 + sh")

--- a/src/test/scala/ru/stachek66/tools/external/ExternalProcessServerTest.scala
+++ b/src/test/scala/ru/stachek66/tools/external/ExternalProcessServerTest.scala
@@ -90,4 +90,115 @@ class ExternalProcessServerTest extends AnyFunSuite {
     (1 to 5).foreach(_ => server.close())
     assert(!server.isAlive)
   }
+
+  // -- syncRequest, in-process via a line-buffered awk echo ---------------
+
+  /** Write a line-buffered echo program in Python and return its path.
+    *
+    * Why Python: GNU `stdbuf -oL cat` works on Linux but not on macOS (BSD
+    * coreutils don't ship `stdbuf`); plain `awk '{print; fflush()}'` line-
+    * buffers OUTPUT but block-buffers INPUT, so a single short line never
+    * gets read until the buffer fills (~4 KB). Python's stdin iterator
+    * with `sys.stdout.flush()` after every line gives us a portable,
+    * bidirectionally line-buffered echo on every CI runner shipping
+    * Python 3 (which is all of them since GitHub Actions ubuntu-22.04+
+    * and macOS-11+).
+    */
+  private def pythonEchoScript(): java.io.File = {
+    val f = java.io.File.createTempFile("mystem-scala-echo-", ".py")
+    f.deleteOnExit()
+    val body =
+      """import sys
+        |for line in sys.stdin:
+        |    sys.stdout.write(line)
+        |    sys.stdout.flush()
+        |""".stripMargin
+    java.nio.file.Files.write(f.toPath, body.getBytes("UTF-8"))
+    f
+  }
+
+  private def hasPython3: Boolean =
+    scala.util.Try {
+      val p = new ProcessBuilder("python3", "--version").redirectErrorStream(true).start()
+      p.waitFor() == 0
+    }.getOrElse(false)
+
+  test("syncRequest writes a line to stdin and returns the line the process emits") {
+    assume(isUnixLike && hasPython3, "needs python3 + sh")
+    val cmd = s"python3 -u ${pythonEchoScript().getAbsolutePath}"
+    val server = new ExternalProcessServer(cmd)
+    try {
+      val result = server.syncRequest("hello world")
+      assert(result.isSuccess, s"expected Success, got $result")
+      assert(result.get === "hello world")
+    } finally server.close()
+  }
+
+  test("syncRequest can be called repeatedly on the same process") {
+    // The wrapper's promise is one round-trip per call, with the same
+    // child surviving across calls. Pin that — a regression where the
+    // process is recreated per request would be a major perf surprise.
+    assume(isUnixLike && hasPython3, "needs python3 + sh")
+    val cmd = s"python3 -u ${pythonEchoScript().getAbsolutePath}"
+    val server = new ExternalProcessServer(cmd)
+    try {
+      assert(server.syncRequest("first").get === "first")
+      assert(server.syncRequest("second").get === "second")
+      assert(server.syncRequest("third").get === "third")
+      // Process should still be the same one we started with.
+      assert(server.isAlive, "the underlying process must outlive multiple syncRequest calls")
+    } finally server.close()
+  }
+
+  test("syncRequest preserves Cyrillic UTF-8 round-trip") {
+    // ExternalProcessServer wraps stdin/stdout in UTF-8 explicitly. Pin
+    // that so a future `Charset.defaultCharset()` regression — which
+    // would silently use the platform default and mangle Cyrillic — gets
+    // caught.
+    assume(isUnixLike && hasPython3, "needs python3 + sh")
+    val cmd = s"python3 -u ${pythonEchoScript().getAbsolutePath}"
+    val server = new ExternalProcessServer(cmd)
+    try {
+      val text = "проверка тестового запуска"
+      assert(server.syncRequest(text).get === text)
+    } finally server.close()
+  }
+
+  test("syncRequest after close() fails (writer already closed)") {
+    // Direct close-after-syncRequest contract. The exact exception type
+    // depends on the underlying Writer's behavior — what we pin is that
+    // it surfaces as a Try.Failure rather than silently returning ""
+    // or hanging.
+    assume(isUnixLike && hasPython3, "needs python3 + sh")
+    val cmd = s"python3 -u ${pythonEchoScript().getAbsolutePath}"
+    val server = new ExternalProcessServer(cmd)
+    server.close()
+    val result = server.syncRequest("anything")
+    assert(result.isFailure, s"expected Failure after close(), got $result")
+  }
+
+  test("syncRequest returns Failure when the child exits before producing any output") {
+    // Pre-fix, the wrapper spun forever in `while (!reader.ready())`
+    // because BufferedReader.ready() returns false at EOF, and the loop
+    // never noticed the child had died. A `mystem` segfault / OOM /
+    // exec-failure would jam the wrapper indefinitely. The fix uses
+    // process.isAlive as a co-condition; this test pins that contract.
+    assume(isUnixLike && hasPython3, "needs python3 + sh")
+    // Tiny script that exits immediately on its first input. No echo.
+    val script = java.io.File.createTempFile("mystem-scala-noecho-", ".py")
+    script.deleteOnExit()
+    java.nio.file.Files.write(
+      script.toPath,
+      "import sys\nsys.stdin.readline()\nsys.exit(0)\n".getBytes("UTF-8")
+    )
+    val server = new ExternalProcessServer(s"python3 -u ${script.getAbsolutePath}")
+    try {
+      val result = server.syncRequest("hello")
+      assert(result.isFailure, s"expected Failure (process exited), got $result")
+      assert(
+        result.failed.get.isInstanceOf[java.io.IOException],
+        s"expected IOException, got ${result.failed.get.getClass.getName}"
+      )
+    } finally server.close()
+  }
 }

--- a/src/test/scala/ru/stachek66/tools/external/FailSafeExternalProcessServerTest.scala
+++ b/src/test/scala/ru/stachek66/tools/external/FailSafeExternalProcessServerTest.scala
@@ -146,4 +146,112 @@ class FailSafeExternalProcessServerTest extends AnyFunSuite {
       )
     }
   }
+
+  // -- syncRequest happy-path + restart-on-failure ------------------------
+
+  /** Line-buffered echo via Python — see ExternalProcessServerTest's
+    * helper for the rationale (awk input-buffers, stdbuf is GNU-only,
+    * Python is universal on modern CI runners).
+    */
+  private def pythonEchoScript(): File = {
+    val f = File.createTempFile("mystem-scala-echo-", ".py")
+    f.deleteOnExit()
+    val body =
+      """import sys
+        |for line in sys.stdin:
+        |    sys.stdout.write(line)
+        |    sys.stdout.flush()
+        |""".stripMargin
+    Files.write(f.toPath, body.getBytes(StandardCharsets.UTF_8))
+    f
+  }
+
+  /** A line echo that exits when it sees the magic line `DIE`. The next
+    * call into FailSafeExternalProcessServer should detect the dead child
+    * and respawn — that's the path we're trying to cover. */
+  private def dieOnCommandScript(): File = {
+    val f = File.createTempFile("mystem-scala-die-", ".py")
+    f.deleteOnExit()
+    val body =
+      """import sys
+        |for line in sys.stdin:
+        |    if line.rstrip("\n") == "DIE":
+        |        sys.exit(0)
+        |    sys.stdout.write(line)
+        |    sys.stdout.flush()
+        |""".stripMargin
+    Files.write(f.toPath, body.getBytes(StandardCharsets.UTF_8))
+    f
+  }
+
+  private def hasPython3: Boolean =
+    scala.util.Try {
+      val p = new ProcessBuilder("python3", "--version").redirectErrorStream(true).start()
+      p.waitFor() == 0
+    }.getOrElse(false)
+
+  test("syncRequest delegates to the wrapped server: line-in, line-out") {
+    assume(isUnixLike && hasPython3, "needs python3 + sh")
+    val cmd = s"python3 -u ${pythonEchoScript().getAbsolutePath}"
+    val s = new FailSafeExternalProcessServer(cmd)
+    try {
+      assert(s.syncRequest("ping").get === "ping")
+      assert(s.syncRequest("ещё один запрос").get === "ещё один запрос")
+    } finally s.close()
+  }
+
+  test("syncRequest restarts the wrapped process if it has died between calls") {
+    // This is the failure-recovery path that justifies wrapping
+    // ExternalProcessServer: if the child dies (mystem segfault, OOM,
+    // whatever), the next caller still gets a fresh child. Without this
+    // restart, every transient failure would manifest as a permanently
+    // broken MyStem instance until the user closed and recreated it.
+    //
+    // We exercise the path by using a script that exits cleanly when it
+    // sees `DIE\n`. After that, the wrapper's `if (!server.isAlive)`
+    // branch fires and a new ExternalProcessServer is spawned for the
+    // next syncRequest.
+    assume(isUnixLike && hasPython3, "needs python3 + sh")
+    val cmd = s"python3 -u ${dieOnCommandScript().getAbsolutePath}"
+    val s = new FailSafeExternalProcessServer(cmd)
+    try {
+      // 1. Establish a baseline: process is alive, syncRequest works.
+      assert(s.syncRequest("hello").get === "hello")
+
+      // 2. Tell the child to die. The Try the wrapper hands back here
+      //    is *expected* to be a failure (the child exited mid-request).
+      //    What we care about is the NEXT call, after the wrapper has
+      //    had a chance to detect the dead child.
+      val _ = s.syncRequest("DIE")
+
+      // Brief pause so the OS has time to tear the process down before
+      // FailSafeExternalProcessServer does its `isAlive` probe.
+      Thread.sleep(100L)
+
+      // 3. The wrapper must spawn a fresh child and round-trip the
+      //    request through it.
+      val recovered = s.syncRequest("after-restart")
+      assert(
+        recovered.isSuccess,
+        s"FailSafe must restart after the child dies; got $recovered"
+      )
+      assert(recovered.get === "after-restart")
+    } finally s.close()
+  }
+
+  test("syncRequest after close() returns Failure, even with a healthy command available") {
+    // Reinforces the closed-state contract: once close() has run, no
+    // further syncRequest should ever spin up a fresh (hookless) child,
+    // even if the underlying script is perfectly capable. This is the
+    // counter-example that proves close() really is final.
+    assume(isUnixLike && hasPython3, "needs python3 + sh")
+    val cmd = s"python3 -u ${pythonEchoScript().getAbsolutePath}"
+    val s = new FailSafeExternalProcessServer(cmd)
+    // Verify it works before close.
+    assert(s.syncRequest("alive").get === "alive")
+    s.close()
+    val after = s.syncRequest("ignored")
+    assert(after.isFailure)
+    assert(after.failed.get.isInstanceOf[IllegalStateException])
+  }
 }

--- a/src/test/scala/ru/stachek66/tools/external/FailSafeExternalProcessServerTest.scala
+++ b/src/test/scala/ru/stachek66/tools/external/FailSafeExternalProcessServerTest.scala
@@ -168,7 +168,8 @@ class FailSafeExternalProcessServerTest extends AnyFunSuite {
 
   /** A line echo that exits when it sees the magic line `DIE`. The next
     * call into FailSafeExternalProcessServer should detect the dead child
-    * and respawn — that's the path we're trying to cover. */
+    * and respawn — that's the path we're trying to cover.
+    */
   private def dieOnCommandScript(): File = {
     val f = File.createTempFile("mystem-scala-die-", ".py")
     f.deleteOnExit()
@@ -184,11 +185,12 @@ class FailSafeExternalProcessServerTest extends AnyFunSuite {
     f
   }
 
-  private def hasPython3: Boolean =
-    scala.util.Try {
+  private def hasPython3: Boolean = scala.util
+    .Try {
       val p = new ProcessBuilder("python3", "--version").redirectErrorStream(true).start()
       p.waitFor() == 0
-    }.getOrElse(false)
+    }
+    .getOrElse(false)
 
   test("syncRequest delegates to the wrapped server: line-in, line-out") {
     assume(isUnixLike && hasPython3, "needs python3 + sh")


### PR DESCRIPTION
https://github.com/alexeyev/mystem-scala/issues/18


- **`GrammarInfo.person` (API change).** The `1p` / `2p` / `3p` person
  tags emitted by mystem are now populated into a new `person:
  Set[Person.Value]` field. Previously the parser silently dropped them
  on the floor. Note: positional constructor calls to `GrammarInfo` will
  break — named-argument call sites are unaffected.
- **Parens-pipe `gr` parsing.** Real mystem 3.x output with `--weight`
  emits multi-analysis strings like
  `A,plen=(acc,sg,m,anim|gen,sg,m|gen,sg,n)`. The pre-existing parser
  threw `NoSuchElementException` on the leading `(`. New
  `GrammarInfoParsing.toGrammarInfos(s): List[GrammarInfo]` returns one
  `GrammarInfo` per pipe-alternative; the previous `toGrammarInfo`
  remains and now returns the most-likely interpretation (mystem orders
  alternatives by descending probability, so `.head`).
- **Wire-format aliases.** mystem 3.x emits `indic` (we declared
  `Value("ind")` for indicative mood) and `praet` (we declared
  `Value("past")` for past tense). Without alias support every real
  verb output threw on parsing. `GrammarMapBuilder.aliases` (public)
  now maps `indic`→`ind` and `praet`→`past`; both forms parse.
- **Process robustness.** `ExternalProcessServer.syncRequest` no
  longer spins forever in `while (!reader.ready()) {}` when the child
  process exits without responding — `BufferedReader.ready()` returns
  `false` at EOF, not true. The busy-wait now also gates on
  `process.isAlive`, the drain loop breaks on `null` (avoiding
  appending the literal string `"null"`), and an exit-without-output
  surfaces as `IOException("process exited before producing any
  response")` so `FailSafeExternalProcessServer` can spawn a fresh
  child rather than wrap an empty success. The restart-on-death path
  is now functionally testable.
- **Refactor:** `Factory.getExecutable`'s cached-binary version check
  is extracted into `private[holding] isCorrectVersion(file, version):
  Boolean`. Same observable contract, but the version-matching logic
  is now exercisable in unit tests without hitting the CDN.
- **Test coverage.** ~70 new tests (75 → 140 across 15 test classes).
  Statement coverage > 80%, branch coverage > 74% under scoverage.
  Direct unit tests for `syncRequest` (using `python3 -u` as a portable
  line-buffered echo stand-in), `isCorrectVersion`, `MyStem.normalize`,
  `MyStemApplicationException`, archive edge cases (empty archive,
  directory-as-first-entry), `FailSafeExternalProcessServer`
  restart-on-death, plus broader coverage of `GrammarInfoParsing`
  (parens-pipe alternatives, person, alias support, fail-loud on
  unknown tags inside parens).